### PR TITLE
add dropout support

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -8,13 +8,14 @@ from kaffe.tensorflow import TensorFlowTransformer
 
 def main():
     args = sys.argv[1:]
-    if len(args) not in (3, 4):
-        print('usage: %s path.prototxt path.caffemodel data-output-path [code-output-path.py]'%os.path.basename(__file__))
+    if len(args) not in (3, 4, 5):
+        print('usage: %s path.prototxt path.caffemodel data-output-path [code-output-path.py] [phase=test]'%os.path.basename(__file__))
         exit(-1)
     def_path, data_path, data_out_path = args[:3]
-    src_out_path = args[3] if len(args)==4 else None
+    src_out_path = args[3] if len(args)>=4 else None
+    phase = args[4] if len(args)>=5 else 'test'
     try:
-        transformer = TensorFlowTransformer(def_path, data_path)
+        transformer = TensorFlowTransformer(def_path, data_path, phase = phase)
         print('Converting data...')
         data = transformer.transform_data()
         print('Saving data...')

--- a/kaffe/layers.py
+++ b/kaffe/layers.py
@@ -113,6 +113,9 @@ class LayerAdapter(NodeDispatch):
     def parameters_memory_data(self):
         return self.layer.memory_data_param
 
+    def parameters_dropout(self):
+        return self.layer.dropout_param
+
     @property
     def parameters(self):
         handler = self.get_handler(self.kind, 'parameters')

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -57,7 +57,7 @@ class Network(object):
     def get_output(self):
         return self.inputs[-1]
 
-    def get_unique_name(self, prefix):        
+    def get_unique_name(self, prefix):
         id = sum(t.startswith(prefix) for t,_ in self.layers.items())+1
         return '%s_%d'%(prefix, id)
 
@@ -72,7 +72,7 @@ class Network(object):
         self.validate_padding(padding)
         c_i = input.get_shape()[-1]
         assert c_i%group==0
-        assert c_o%group==0        
+        assert c_o%group==0
         convolve = lambda i, k: tf.nn.conv2d(i, k, [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
             kernel = self.make_var('weights', shape=[k_h, k_w, c_i/group, c_o])
@@ -83,7 +83,7 @@ class Network(object):
                 input_groups = tf.split(3, group, input)
                 kernel_groups = tf.split(3, group, kernel)
                 output_groups = [convolve(i, k) for i,k in zip(input_groups, kernel_groups)]
-                conv = tf.concat(3, output_groups)                
+                conv = tf.concat(3, output_groups)
             if relu:
                 bias = tf.reshape(tf.nn.bias_add(conv, biases), conv.get_shape().as_list())
                 return tf.nn.relu(bias, name=scope.name)
@@ -145,3 +145,6 @@ class Network(object):
     def softmax(self, input, name):
         return tf.nn.softmax(input, name)
 
+    @layer
+    def dropout(self, input, keep_prob, name):
+        return tf.nn.dropout(input, keep_prob, name=name)


### PR DESCRIPTION
Currently, only testing time network is supported. Therefore, the dropout layer is happily ignored.

This PR makes it possible to export training time network, which includes dropout layer.