### PR TITLE
Added a switch variable which allows it to disable dropout 

### DIFF
--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -40,6 +40,10 @@ class Network(object):
         self.layers = dict(inputs)
         # If true, the resulting variables are set as trainable
         self.trainable = trainable
+        # Switch variable for dropout
+        self.use_dropout = tf.placeholder_with_default(tf.constant(1.0),
+                                                       shape=[],
+                                                       name='use_dropout')
         self.setup()
 
     def setup(self):
@@ -236,4 +240,5 @@ class Network(object):
 
     @layer
     def dropout(self, input, keep_prob, name):
-        return tf.nn.dropout(input, keep_prob, name=name)
+        keep = 1 - self.use_dropout + (self.use_dropout * keep_prob)
+        return tf.nn.dropout(input, keep, name=name)


### PR DESCRIPTION
When converting a model that has dropout it gets either ignored (when choosing test as a phase) or added constantly. However in many cases the user want to add/remove dropout on the fly, e.g. use dropout when training but then switch it off for validation/predictions.

With this PR I introduce a switch which gives the user the ability to explicitly switch on and off dropout even after the model is loaded. For that I use a placeholder which can be feed when running the model, e.g.
`sess.run(prob, feed_dict={input: images, net.use_dropout: 0.0})`
for switching off dropout (or 1.0 for using dropout). The placeholder has a default value of 1.0 which means that dropout is turned on, so the default behavior is not changing. I hope you also find this a useful addition to the network.