### PR TITLE
bug fix for softmax layer in network.py

### DIFF
--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -212,7 +212,7 @@ class Network(object):
                 input = tf.squeeze(input, squeeze_dims=[1, 2])
             else:
                 raise ValueError('Rank 2 tensor input expected for softmax!')
-        return tf.nn.softmax(input, name)
+        return tf.nn.softmax(input, name=name)
 
     @layer
     def batch_normalization(self, input, name, scale_offset=True, relu=False):


### PR DESCRIPTION
`name` is not second but third argument for `tf.nn.softmax` for TensorFlow v0.12.0.
Therefore, we have to state explicitly as `name=...` when we do not use the second argument `dim`.

https://www.tensorflow.org/api_docs/python/nn/classification#softmax