### PR TITLE
Changed method call of tf.resize_images

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -42,7 +42,7 @@ def convert(def_path, caffemodel_path, data_output_path, code_output_path, phase
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('def_path', help='Model definition (.prototxt) path')
+    parser.add_argument('--def-path', help='Model definition (.prototxt) path')
     parser.add_argument('--caffemodel', help='Model data (.caffemodel) path')
     parser.add_argument('--data-output-path', help='Converted data output path')
     parser.add_argument('--code-output-path', help='Save generated source to this path')

--- a/examples/imagenet/dataset.py
+++ b/examples/imagenet/dataset.py
@@ -20,7 +20,7 @@ def process_image(img, scale, isotropic, crop, mean):
         new_shape = tf.to_int32((scale / min_length) * img_shape)
     else:
         new_shape = tf.pack([scale, scale])
-    img = tf.image.resize_images(img, new_shape[0], new_shape[1])
+    img = tf.image.resize_images(img, new_shape)
     # Center crop
     # Use the slice workaround until crop_to_bounding_box supports deferred tensor shapes
     # See: https://github.com/tensorflow/tensorflow/issues/521


### PR DESCRIPTION
Since version 0.12.0-rc0 the method tf.resize_images expects a 1D Tensor with two elements. Fixed this in examples/imagenet/dataset.py . :)
Also I renamed the "def_path" arguments to "def-path" of convert.py. I added two dashes in front of def-path, because the other parameters start with two dashes and now it looks more consistent.