### PR TITLE
revise the repo to fit the new tensorflow (1.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 # Python cache
 *.pyc
 
+# python numpy data files
+*.npy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Caffe to TensorFlow
+# Caffe to TensorFlow-1.2
 
+Some minor changes to the [Caffe-to-Tensorflow](https://github.com/ethereon/caffe-tensorflow) project, supporting the latest version of tensorflow (1.2). 
 Convert [Caffe](https://github.com/BVLC/caffe/) models to [TensorFlow](https://github.com/tensorflow/tensorflow).
 
 ## Usage

--- a/examples/imagenet/dataset.py
+++ b/examples/imagenet/dataset.py
@@ -19,13 +19,13 @@ def process_image(img, scale, isotropic, crop, mean):
         min_length = tf.minimum(img_shape[0], img_shape[1])
         new_shape = tf.to_int32((scale / min_length) * img_shape)
     else:
-        new_shape = tf.pack([scale, scale])
-    img = tf.image.resize_images(img, new_shape[0], new_shape[1])
+        new_shape = tf.stack([scale, scale])
+    img = tf.image.resize_images(img, new_shape)
     # Center crop
     # Use the slice workaround until crop_to_bounding_box supports deferred tensor shapes
     # See: https://github.com/tensorflow/tensorflow/issues/521
     offset = (new_shape - crop) / 2
-    img = tf.slice(img, begin=tf.pack([offset[0], offset[1], 0]), size=tf.pack([crop, crop, -1]))
+    img = tf.slice(img, begin=tf.stack([offset[0], offset[1], 0]), size=tf.stack([crop, crop, -1]))
     # Mean subtraction
     return tf.to_float(img) - mean
 
@@ -126,7 +126,7 @@ class ImageProducer(object):
         if self.data_spec.expects_bgr:
             # Convert from RGB channel ordering to BGR
             # This matches, for instance, how OpenCV orders the channels.
-            img = tf.reverse(img, [False, False, True])
+            img = tf.reverse(img, [2])
         return img
 
     def process(self):

--- a/examples/mnist/finetune_mnist.py
+++ b/examples/mnist/finetune_mnist.py
@@ -37,13 +37,13 @@ net = MyNet({'data': images})
 ip2 = net.layers['ip2']
 pred = tf.nn.softmax(ip2)
 
-loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(ip2, labels), 0)
+loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=ip2, labels=labels), 0)
 opt = tf.train.RMSPropOptimizer(0.001)
 train_op = opt.minimize(loss)
 
 with tf.Session() as sess:
     # Load the data
-    sess.run(tf.initialize_all_variables())
+    sess.run(tf.global_variables_initializer())
     net.load('mynet.npy', sess)
 
     data_gen = gen_data_batch(mnist.train)

--- a/examples/mnist/finetune_mnist.py
+++ b/examples/mnist/finetune_mnist.py
@@ -30,8 +30,8 @@ def gen_data_batch(source):
         yield np.array(image_batch), np.array(label_batch)
 
 
-images = tf.placeholder(tf.float32, [batch_size, 28, 28, 1])
-labels = tf.placeholder(tf.float32, [batch_size, 10])
+images = tf.placeholder(tf.float32, [None, 28, 28, 1])
+labels = tf.placeholder(tf.float32, [None, 10])
 net = MyNet({'data': images})
 
 ip2 = net.layers['ip2']
@@ -49,8 +49,11 @@ with tf.Session() as sess:
     data_gen = gen_data_batch(mnist.train)
     for i in range(1000):
         np_images, np_labels = next(data_gen)
-        feed = {images: np_images, labels: np_labels}
+        np_loss, np_pred, _ = sess.run([loss, pred, train_op], feed_dict={images: np_images, labels: np_labels})
 
-        np_loss, np_pred, _ = sess.run([loss, pred, train_op], feed_dict=feed)
         if i % 10 == 0:
-            print('Iteration: ', i, np_loss)
+            correct_prediction = tf.equal(tf.argmax(pred, 1), tf.argmax(labels, 1))
+            accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+            np_accuracy = sess.run(accuracy, feed_dict={images: np_images, labels: np_labels})
+            print('Iteration: ', i, np_loss, np_accuracy)
+

--- a/examples/mnist/finetune_mnist.py
+++ b/examples/mnist/finetune_mnist.py
@@ -35,7 +35,7 @@ labels = tf.placeholder(tf.float32, [batch_size, 10])
 net = MyNet({'data': images})
 
 ip2 = net.layers['ip2']
-pred = tf.nn.softmax(ip2)
+pred = net.layers['prob']
 
 loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=ip2, labels=labels), 0)
 opt = tf.train.RMSPropOptimizer(0.001)

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -177,7 +177,7 @@ class Network(object):
 
     @layer
     def concat(self, inputs, axis, name):
-        return tf.concat(concat_dim=axis, values=inputs, name=name)
+        return tf.concat(axis=axis, values=inputs, name=name)
 
     @layer
     def add(self, inputs, name):

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -124,7 +124,7 @@ class Network(object):
         # Convolution for a given input and kernel
         convolve = lambda i, k: tf.nn.conv2d(i, k, [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
-            kernel = self.make_var('weights', shape=[k_h, k_w, c_i / group, c_o])
+            kernel = self.make_var('kernel', shape=[k_h, k_w, c_i / group, c_o])
             if group == 1:
                 # This is the common-case. Convolve the input without any further complications.
                 output = convolve(input, kernel)
@@ -135,10 +135,10 @@ class Network(object):
                 output_groups = [convolve(i, k) for i, k in zip(input_groups, kernel_groups)]
                 # Concatenate the groups
                 output = tf.concat(3, output_groups)
-            # Add the biases
+            # Add the bias
             if biased:
-                biases = self.make_var('biases', [c_o])
-                output = tf.nn.bias_add(output, biases)
+                bias = self.make_var('bias', [c_o])
+                output = tf.nn.bias_add(output, bias)
             if relu:
                 # ReLU non-linearity
                 output = tf.nn.relu(output, name=scope.name)
@@ -195,10 +195,10 @@ class Network(object):
                 feed_in = tf.reshape(input, [-1, dim])
             else:
                 feed_in, dim = (input, input_shape[-1].value)
-            weights = self.make_var('weights', shape=[dim, num_out])
-            biases = self.make_var('biases', [num_out])
+            weights = self.make_var('kernel', shape=[dim, num_out])
+            bias = self.make_var('bias', [num_out])
             op = tf.nn.relu_layer if relu else tf.nn.xw_plus_b
-            fc = op(feed_in, weights, biases, name=scope.name)
+            fc = op(feed_in, weights, bias, name=scope.name)
             return fc
 
     @layer

--- a/kaffe/transformers.py
+++ b/kaffe/transformers.py
@@ -72,7 +72,7 @@ class DataInjector(object):
         # potential for future issues.
         # The Caffe-backend does not suffer from this problem.
         data = list(data)
-        squeeze_indices = [1]  # Squeeze biases.
+        squeeze_indices = [1]  # Squeeze bias.
         if node.kind == NodeKind.InnerProduct:
             squeeze_indices.append(0)  # Squeeze FC.
         for idx in squeeze_indices:
@@ -275,9 +275,9 @@ class ParameterNamer(object):
             if node.data is None:
                 continue
             if node.kind in (NodeKind.Convolution, NodeKind.InnerProduct):
-                names = ('weights',)
+                names = ('kernel',)
                 if node.parameters.bias_term:
-                    names += ('biases',)
+                    names += ('bias',)
             elif node.kind == NodeKind.BatchNorm:
                 names = ('mean', 'variance')
                 if len(node.data) == 4:


### PR DESCRIPTION
* fix version issues with the newest tensorflow (softmax_cross_entropy_with_logits came with optional parameters, use 'global_variables_initializer' instead of 'initialize_all_variables'
* The official tf network wrapper use 'kernel' and 'bias' for 'weights' and 'biases'.